### PR TITLE
Update test commands

### DIFF
--- a/monorepo/package.json
+++ b/monorepo/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test:unit": "lerna run test:unit",
-    "test:e2e": "lerna run test:e2e:dev"
+    "test:e2e": "lerna run test:e2e:dev:bg"
   },
   "workspaces": [
     "packages/*"

--- a/monorepo/packages/add-button/package.json
+++ b/monorepo/packages/add-button/package.json
@@ -50,8 +50,8 @@
     "lint": "eslint '*/**/*.{tsx,ts,js}' --fix",
     "prettier": "prettier --write './**/*.{tsx,ts,js}'",
     "test:unit": "jest --testPathIgnorePatterns dist/*",
-    "test:e2e": "nightwatch --env firefox",
-    "test:e2e:dev": "bash ../../test/nightwatch_runner.sh"
+    "test:e2e:dev": "nightwatch --env firefox",
+    "test:e2e:dev:bg": "bash ../../test/nightwatch_runner.sh"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/monorepo/packages/sub-button/package.json
+++ b/monorepo/packages/sub-button/package.json
@@ -50,8 +50,8 @@
     "lint": "eslint '*/**/*.{tsx,ts,js}' --fix",
     "prettier": "prettier --write './**/*.{tsx,ts,js}'",
     "test:unit": "jest --testPathIgnorePatterns dist/*",
-    "test:e2e": "nightwatch --env firefox",
-    "test:e2e:dev": "bash ../../test/nightwatch_runner.sh"
+    "test:e2e:dev": "nightwatch --env firefox",
+    "test:e2e:dev:bg": "bash ../../test/nightwatch_runner.sh"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/monorepo/packages/wps-button-template-test/package.json
+++ b/monorepo/packages/wps-button-template-test/package.json
@@ -50,9 +50,9 @@
     "lint": "eslint '*/**/*.{tsx,ts,js}' --fix",
     "prettier": "prettier --write './**/*.{tsx,ts,js}'",
     "test:unit": "jest --testPathIgnorePatterns dist/*",
-    "test:e2e": "nightwatch --env chrome",
+    "test:e2e:dev": "nightwatch --env chrome",
     "test:e2e:md": "nightwatch --env chromeMD",
-    "test:e2e:dev": "bash ../../test/nightwatch_runner.sh"
+    "test:e2e:dev:bg": "bash ../../test/nightwatch_runner.sh"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/monorepo/test/README.md
+++ b/monorepo/test/README.md
@@ -15,7 +15,9 @@ Utilizing the `lerna run <script>` command, we can run tests for all packages al
 
 ## Testing individual package
 - **unit test**: run `yarn test:unit` <br>
-- **e2e test**: run `yarn test:e2e` <br>
+- **e2e test with dev server**: run `yarn test:e2e:dev` <br>
+- **e2e test with md**: run `yarn test:e2e:md` <br>
+- **e2e test with dev server in background **: run `yarn test:e2e:dev:bg` <br>
 - `test/nightwatch_runner.sh`: a helper script for running nightwatch e2e tests. It starts the server in background and then run tests.
 
 ## Testing globally

--- a/monorepo/test/nightwatch_runner.sh
+++ b/monorepo/test/nightwatch_runner.sh
@@ -10,7 +10,7 @@ sleep 5
 
 # Runs e2e tests
 #
-yarn test:e2e
+yarn test:e2e:dev
 
 # Get test exit status, kill the process and exit
 #


### PR DESCRIPTION
- Update test:e2e to test:e2e:dev
- Add command test:e2e:dev:bg which utilizes a global runner script for running e2e tests with a background dev server
